### PR TITLE
test_tc_017_03_05_the_field_api_key_name_displayed_in_modal_window added

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -20,10 +20,8 @@ class ApiKeysPage(BasePage):
         edit_api_key_icon.click()
         self.driver.switch_to.default_content()
 
-    def enter_new_api_name(self, new_api_name):
-        api_key_field = self.element_is_clickable(ApiKeysLocator.API_KEY_FIELD, 10)
-        api_key_field.click()
-        api_key_field.clear()
+    def enter_new_api_key_name(self, new_api_name):
+        api_key_field = self.clear_the_field(ApiKeysLocator.API_KEY_FIELD)
         api_key_field.send_keys(new_api_name)
 
     def click_save_new_api_key_name_button(self):
@@ -187,7 +185,7 @@ class ApiKeysPage(BasePage):
         assert actual_alert_text == expected_alert_text1 or expected_alert_text2, \
             "The alert text does not correspond to expected"
 
-    def check_is_notice_API_key_status_change_is_displayed(self):
+    def check_is_notice_API_key_status_changed_is_displayed(self):
         expected_notice1 = 'API key was activated successfully'
         expected_notice2 = "API key was deactivated successfully"
         change_api_key_status_icon = self.element_is_clickable(ApiKeysLocator.CHANGE_API_KEY_STATUS_ICON)
@@ -220,5 +218,10 @@ class ApiKeysPage(BasePage):
     def is_displayed_modal_window_for_change_api_key_name(self):
         modal_window_for_change_api_key_name = self.element_is_visible(ApiKeysLocator.MODAL_WINDOW_EDIT_API_KEY_NAME,
                                                                        10)
-        assert modal_window_for_change_api_key_name.text == "Edit API key name",\
+        assert modal_window_for_change_api_key_name.text == "Edit API key name", \
             "The modal window Edit API key name does not displayed"
+
+    def check_is_displayed_field_api_key_name(self):
+        assert self.element_is_displayed(ApiKeysLocator.API_KEY_FIELD), "The field 'API key name' does not display"
+
+

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -149,3 +149,8 @@ class BasePage:
 
     def title_check(self, text=None):
         assert self.driver.title == text, "Title is NOT correct"
+
+    def clear_the_field(self, field_element, timeout=5):
+        field = wait(self.driver, timeout).until(EC.element_to_be_clickable(field_element))
+        field.clear()
+        return field

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -63,7 +63,7 @@ class TestApiKey:
     def test_tc_017_02_07_notice_API_key_status_change_is_displayed(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()
-        api_keys_page.check_is_notice_API_key_status_change_is_displayed()
+        api_keys_page.check_is_notice_API_key_status_changed_is_displayed()
 
     def test_tc_017_02_08_the_active_status_of_api_key_is_black(self, driver):
         row_num = 1
@@ -112,6 +112,12 @@ class TestApiKey:
         api_keys_page.open_api_keys_page()
         api_keys_page.open_popup_rename_api_key()
         api_keys_page.is_displayed_modal_window_for_change_api_key_name()
+
+    def test_tc_017_03_05_the_field_api_key_name_displayed_in_modal_window(self, driver):
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.open_popup_rename_api_key()
+        api_keys_page.check_is_displayed_field_api_key_name()
 
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -98,7 +98,7 @@ class TestApiKey:
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()
         api_keys_page.open_popup_rename_api_key()
-        api_keys_page.enter_new_api_name("Changed API key name")
+        api_keys_page.enter_new_api_key_name("Changed API key name")
         api_keys_page.click_save_new_api_key_name_button()
         api_keys_page.check_if_api_key_name_displayed()
 


### PR DESCRIPTION
AT_017.03.05 : https://trello.com/c/hdOcAiQf/665-attc0170305-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keys-the-entered-api-key-name-is-displayed-in-the-fil
TC_017.03.05 : https://trello.com/c/aoWv2RNU/42-tc0170305-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keys-the-entered-api-key-name-display-in-the-filed-api