### PR TITLE
test_tc_017_03_07_the_api_key_name_is_not_changed added

### DIFF
--- a/locators/API_keys_locators.py
+++ b/locators/API_keys_locators.py
@@ -25,7 +25,8 @@ class ApiKeysLocator:
     STATUS_COLOR = By.CSS_SELECTOR, "span:nth-child(1)"
     CHANGE_API_KEY_STATUS_ICON = By.XPATH, "//a[@data-method='put']"
     NOTICE_STATUS_API_KEY_CHANGED = By.CSS_SELECTOR, '.panel-body'
-    MODAL_WINDOW_EDIT_API_KEY_NAME= By.CSS_SELECTOR, "div[class='pop-up-header'] h3"
+    MODAL_WINDOW_EDIT_API_KEY_NAME = By.CSS_SELECTOR, "div[class='pop-up-header'] h3"
+    CANCEL_NEW_API_NAME_BUTTON = By.CSS_SELECTOR, '.pop-up-footer .transparent'
 
 
 

--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -28,6 +28,10 @@ class ApiKeysPage(BasePage):
         save_api_key_name_button = self.driver.find_element(*ApiKeysLocator.SAVE_NEW_API_NAME_BUTTON)
         save_api_key_name_button.click()
 
+    def click_cancel_new_api_key_name_button(self):
+        cancel_button = self.element_is_clickable(ApiKeysLocator.CANCEL_NEW_API_NAME_BUTTON)
+        cancel_button.click()
+
     def api_key_name_of_first_row(self):
         return self.driver.find_element(*ApiKeysLocator.API_KEY_NAME_FIRST_ROW).text
 
@@ -228,5 +232,6 @@ class ApiKeysPage(BasePage):
         new_api_key_name = self.api_key_name_of_first_row()
         assert new_api_key_name == api_key_name, "The entered API key name is not saved."
 
-
-
+    def check_if_api_key_name_is_not_changed(self, api_key_name):
+        expected_api_key_name = self.api_key_name_of_first_row()
+        assert expected_api_key_name == api_key_name, "The API key name changes after clicking the 'Cancel' button."

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -195,6 +195,22 @@ class TestApiKey:
         api_keys_page.click_save_new_api_key_name_button()
         api_keys_page.check_is_saved_new_api_key_name(new_api_key_name)
 
+    @allure.severity(allure.severity_level.NORMAL)
+    @allure.story("US_017.03")
+    @allure.feature("API key name change")
+    def test_tc_017_03_07_the_api_key_name_is_not_changed(self, driver):
+        """
+        In this test case , it is checked that the API key name has not changed after clicking "Cancel" button.
+        """
+        new_api_key_name = "any API key name "
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        initial_api_key_name = api_keys_page.api_key_name_of_first_row()
+        api_keys_page.open_popup_rename_api_key()
+        api_keys_page.enter_new_api_key_name(new_api_key_name)
+        api_keys_page.click_cancel_new_api_key_name_button()
+        api_keys_page.check_if_api_key_name_is_not_changed(initial_api_key_name)
+
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()


### PR DESCRIPTION
TC_017.03.07 : https://trello.com/c/TMxMeZau/44-tc0170307-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-after-clicking-can
AT_017.03.07 : https://trello.com/c/W63yMjoR/667-attc0170307-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-after-clicking-c