### PR TITLE
test_tc_017_03_08_the_api_key_name_is_not_changed_close_icon added

### DIFF
--- a/locators/API_keys_locators.py
+++ b/locators/API_keys_locators.py
@@ -27,6 +27,7 @@ class ApiKeysLocator:
     NOTICE_STATUS_API_KEY_CHANGED = By.CSS_SELECTOR, '.panel-body'
     MODAL_WINDOW_EDIT_API_KEY_NAME = By.CSS_SELECTOR, "div[class='pop-up-header'] h3"
     CANCEL_NEW_API_NAME_BUTTON = By.CSS_SELECTOR, '.pop-up-footer .transparent'
+    CLOSE_POPUP_NEW_API_KEY_NAME_ICON = By.CSS_SELECTOR, "a[data-dismiss='modal']"
 
 
 

--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -32,6 +32,10 @@ class ApiKeysPage(BasePage):
         cancel_button = self.element_is_clickable(ApiKeysLocator.CANCEL_NEW_API_NAME_BUTTON)
         cancel_button.click()
 
+    def click_close_icon_of_new_api_key_name_popup(self):
+        cancel_button = self.element_is_clickable(ApiKeysLocator.CLOSE_POPUP_NEW_API_KEY_NAME_ICON)
+        cancel_button.click()
+
     def api_key_name_of_first_row(self):
         return self.driver.find_element(*ApiKeysLocator.API_KEY_NAME_FIRST_ROW).text
 
@@ -219,7 +223,7 @@ class ApiKeysPage(BasePage):
         edit_api_key_icon = self.element_is_displayed(ApiKeysLocator.EDIT_API_KEY_ICON)
         assert edit_api_key_icon, "The icon for editing API key name is not displayed."
 
-    def is_displayed_modal_window_for_change_api_key_name(self):
+    def check_is_displayed_modal_window_for_change_api_key_name(self):
         modal_window_for_change_api_key_name = self.element_is_visible(ApiKeysLocator.MODAL_WINDOW_EDIT_API_KEY_NAME,
                                                                        10)
         assert modal_window_for_change_api_key_name.text == "Edit API key name", \
@@ -232,6 +236,10 @@ class ApiKeysPage(BasePage):
         new_api_key_name = self.api_key_name_of_first_row()
         assert new_api_key_name == api_key_name, "The entered API key name is not saved."
 
-    def check_if_api_key_name_is_not_changed(self, api_key_name):
+    def check_if_api_key_name_is_not_changed_clicking_cancel_button(self, api_key_name):
         expected_api_key_name = self.api_key_name_of_first_row()
         assert expected_api_key_name == api_key_name, "The API key name changes after clicking the 'Cancel' button."
+        
+    def check_if_api_key_name_is_not_changed_clicking_close_icon(self, api_key_name):
+        expected_api_key_name = self.api_key_name_of_first_row()
+        assert expected_api_key_name == api_key_name, "The API key name changes after clicking the 'Close' icon."

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -178,7 +178,7 @@ class TestApiKey:
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()
         api_keys_page.open_popup_rename_api_key()
-        api_keys_page.is_displayed_modal_window_for_change_api_key_name()
+        api_keys_page.check_is_displayed_modal_window_for_change_api_key_name()
 
     def test_tc_017_03_05_the_field_api_key_name_displayed_in_modal_window(self, driver):
         api_keys_page = ApiKeysPage(driver)
@@ -198,7 +198,7 @@ class TestApiKey:
     @allure.severity(allure.severity_level.NORMAL)
     @allure.story("US_017.03")
     @allure.feature("API key name change")
-    def test_tc_017_03_07_the_api_key_name_is_not_changed(self, driver):
+    def test_tc_017_03_07_the_api_key_name_is_not_changed_cancel_button(self, driver):
         """
         In this test case , it is checked that the API key name has not changed after clicking "Cancel" button.
         """
@@ -209,7 +209,23 @@ class TestApiKey:
         api_keys_page.open_popup_rename_api_key()
         api_keys_page.enter_new_api_key_name(new_api_key_name)
         api_keys_page.click_cancel_new_api_key_name_button()
-        api_keys_page.check_if_api_key_name_is_not_changed(initial_api_key_name)
+        api_keys_page.check_if_api_key_name_is_not_changed_clicking_cancel_button(initial_api_key_name)
+
+    @allure.severity(allure.severity_level.NORMAL)
+    @allure.story("US_017.03")
+    @allure.feature("API key name change")
+    def test_tc_017_03_08_the_api_key_name_is_not_changed_close_icon(self, driver):
+        """
+        In this test case , it is checked that the API key name has not changed after clicking popup's "Close" icon.
+        """
+        new_api_key_name = "any API key name "
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        initial_api_key_name = api_keys_page.api_key_name_of_first_row()
+        api_keys_page.open_popup_rename_api_key()
+        api_keys_page.enter_new_api_key_name(new_api_key_name)
+        api_keys_page.click_close_icon_of_new_api_key_name_popup()
+        api_keys_page.check_if_api_key_name_is_not_changed_clicking_close_icon(initial_api_key_name)
 
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)


### PR DESCRIPTION
AT_017.03.08 : https://trello.com/c/stOgldSD/668-at0170308-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-after-clicking-clo
TC_017.03.08 : https://trello.com/c/xvRhCy2N/45-tc0170308-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-after-clicking-clo