### PR TITLE
test_tc_017_03_09_the_api_key_name_is_not_changed_if_field_empty added

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -20,6 +20,9 @@ class ApiKeysPage(BasePage):
         edit_api_key_icon.click()
         self.driver.switch_to.default_content()
 
+    def clear_new_api_key_name_field(self):
+        self.clear_the_field(ApiKeysLocator.API_KEY_FIELD)
+
     def enter_new_api_key_name(self, new_api_name):
         api_key_field = self.clear_the_field(ApiKeysLocator.API_KEY_FIELD)
         api_key_field.send_keys(new_api_name)
@@ -243,3 +246,8 @@ class ApiKeysPage(BasePage):
     def check_if_api_key_name_is_not_changed_clicking_close_icon(self, api_key_name):
         expected_api_key_name = self.api_key_name_of_first_row()
         assert expected_api_key_name == api_key_name, "The API key name changes after clicking the 'Close' icon."
+
+    def check_api_key_name_remains_unchanged_if_new_name_is_not_entered(self, api_key_name):
+        expected_api_key_name = self.api_key_name_of_first_row()
+        assert expected_api_key_name == api_key_name, " API key name is changed when the user clears the " \
+                                                      "New API key name field and clicks the Save button."

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -227,6 +227,22 @@ class TestApiKey:
         api_keys_page.click_close_icon_of_new_api_key_name_popup()
         api_keys_page.check_if_api_key_name_is_not_changed_clicking_close_icon(initial_api_key_name)
 
+    @allure.severity(allure.severity_level.TRIVIAL)
+    @allure.story("US_017.03")
+    @allure.feature("API key name change")
+    def test_tc_017_03_09_the_api_key_name_is_not_changed_if_field_empty(self, driver):
+        """
+        In this test case, we are checking whether the API key name remains unchanged when
+         the user clears the "New API key name" field and clicks the "Save" button.
+        """
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        initial_api_key_name = api_keys_page.api_key_name_of_first_row()
+        api_keys_page.open_popup_rename_api_key()
+        api_keys_page.clear_new_api_key_name_field()
+        api_keys_page.click_save_new_api_key_name_button()
+        api_keys_page.check_api_key_name_remains_unchanged_if_new_name_is_not_entered(initial_api_key_name)
+
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()


### PR DESCRIPTION
TC_017.03.09 : https://trello.com/c/zqVUflkC/662-tc0170309-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-if-the-new-name-do
AT_017.03.09 : https://trello.com/c/mtnSMOLl/669-attc0170309-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-if-the-new-name
