### PR TITLE
test_tc_017_03_010_the_api_key_name_is_not_changed_using_spaces added

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -251,3 +251,7 @@ class ApiKeysPage(BasePage):
         expected_api_key_name = self.api_key_name_of_first_row()
         assert expected_api_key_name == api_key_name, " API key name is changed when the user clears the " \
                                                       "New API key name field and clicks the Save button."
+
+    def check_api_key_name_remains_unchanged_when_new_name_entered_as_spaces(self, api_key_name):
+        expected_api_key_name = self.api_key_name_of_first_row()
+        assert expected_api_key_name == api_key_name, " API key name is changed when the user enter spaces."

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -243,6 +243,23 @@ class TestApiKey:
         api_keys_page.click_save_new_api_key_name_button()
         api_keys_page.check_api_key_name_remains_unchanged_if_new_name_is_not_entered(initial_api_key_name)
 
+    @allure.severity(allure.severity_level.NORMAL)
+    @allure.story("US_017.03")
+    @allure.feature("API key name change")
+    def test_tc_017_03_010_the_api_key_name_is_not_changed_using_spaces(self, driver):
+        """
+        In this test case, we are checking whether the API key name remains unchanged when a new API name
+         is entered using spaces
+        """
+        new_api_key_name = "        "
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        initial_api_key_name = api_keys_page.api_key_name_of_first_row()
+        api_keys_page.open_popup_rename_api_key()
+        api_keys_page.enter_new_api_key_name(new_api_key_name)
+        api_keys_page.click_save_new_api_key_name_button()
+        api_keys_page.check_api_key_name_remains_unchanged_when_new_name_entered_as_spaces(initial_api_key_name)
+
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()


### PR DESCRIPTION
AT_017.03.10 : https://trello.com/c/iXMb0SUJ/670-attc0170310-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-if-the-new-name
TC_017.03.10 : https://trello.com/c/KDUysNxG/663-tc0170310-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keysthe-api-key-name-has-not-changed-if-the-new-name-is