### PR TITLE
test_tc_017_03_11_the_new_api_key_name_field_has_limit_20_symbols added

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -1,4 +1,4 @@
-import time
+
 
 from pages.base_page import BasePage
 from locators.API_keys_locators import ApiKeysLocator
@@ -86,11 +86,13 @@ class ApiKeysPage(BasePage):
         module_create_api_key = self.driver.find_element(*ApiKeysLocator.MODULE_API_KEY_CREATE)
         assert module_create_api_key.is_displayed(), "module with title “Create key“ is not visible"
 
-    def check_limit_of_api_key_name(self):
-        api_name_limit = 20
-        actual_length_of_api_key_name = len(self.api_key_name_of_first_row())
-        assert actual_length_of_api_key_name == api_name_limit, "The limit of API key name is not correspond to " \
-                                                                "expected limit"
+    def check_limit_of_api_key_name_field(self):
+        api_key_name_field_limit = 20
+        api_key_name_field = self.driver.find_element(*ApiKeysLocator.API_KEY_FIELD)
+        actual_length_of_api_key_name_field = int(api_key_name_field.get_attribute('maxlength'))
+        assert actual_length_of_api_key_name_field == api_key_name_field_limit, "The limit of API key name field  is not correspond to " \
+                                                                "expected limit."
+
 
     def check_limit_of_created_api_key_name(self):
         expected_api_name_limit = 20

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -260,6 +260,19 @@ class TestApiKey:
         api_keys_page.click_save_new_api_key_name_button()
         api_keys_page.check_api_key_name_remains_unchanged_when_new_name_entered_as_spaces(initial_api_key_name)
 
+    @allure.severity(allure.severity_level.NORMAL)
+    @allure.story("US_017.03")
+    @allure.feature("API key name change")
+    def test_tc_017_03_11_the_new_api_key_name_field_has_limit_20_symbols(self, driver):
+        """
+        In this test case, we are checking whether the API key name field(that in the popup "Edit API key name")
+         has a limit 20 symbols
+        """
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.open_popup_rename_api_key()
+        api_keys_page.check_limit_of_api_key_name_field()
+
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()


### PR DESCRIPTION
AT_017.03.11: https://trello.com/c/7KBSATee/672-at0170311-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keys-the-entered-new-api-key-name-has-a-limit-of-20-sym
TC_017.03.11 : https://trello.com/c/mwviDghs/664-tc0170311-api-keys-tab-rename-api-key-visibility-clickability-rename-api-keys-the-entered-new-api-key-name-has-a-limit-of-20-sym