### PR TITLE
test_tc_017_05_06_the_api_key_is_deleted_when_clicking_ok_button

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -313,3 +313,10 @@ class ApiKeysPage(BasePage):
         alert.dismiss()
         actual_row_number = self.get_length_of_table_api_keys()
         assert actual_row_number == initial_row_number, "The API key is deleted ."
+
+    def check_api_key_is_deleted(self, rows):
+        initial_row_number = rows
+        alert = self.driver.switch_to.alert
+        alert.accept()
+        actual_row_number = self.get_length_of_table_api_keys()
+        assert actual_row_number == initial_row_number - 1, "The API key is deleted ."

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -397,6 +397,19 @@ class TestApiKey:
         api_keys_page.click_delete_api_key_icon()
         api_keys_page.check_api_key_is_not_deleted(rows)
 
+    @allure.severity(allure.severity_level.NORMAL)
+    @allure.story("US_017.05")
+    @allure.feature("Delete API key ")
+    def test_tc_017_05_06_the_api_key_is_deleted_when_clicking_ok_button(self, driver):
+        """
+            In this test case, we are checking whether the API key is deleted when clicking the 'OK' button.
+        """
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.add_row_in_table()
+        rows = api_keys_page.get_length_of_table_api_keys()
+        api_keys_page.click_delete_api_key_icon()
+        api_keys_page.check_api_key_is_deleted(rows)
 
 
 


### PR DESCRIPTION
TC_017.05.06 : https://trello.com/c/pn7sC3kQ/684-tc0170505-api-keys-tabdeleting-api-key-visibility-clickabilitydeletingthe-api-key-is-not-deleted-when-clicking-the-cancel-button
AT_017.05.06 : https://trello.com/c/TbcJBt9x/685-at0170506-api-keys-tabdeleting-api-key-visibility-clickabilitydeletingthe-api-key-is-deleted-from-api-keys-table-when-clicking-t